### PR TITLE
New Discriminator Conditional

### DIFF
--- a/src/lib/Discord.php
+++ b/src/lib/Discord.php
@@ -115,7 +115,7 @@ class Discord {
 		}
 
 		$user_data = json_decode( $user_data, true );
-		if ( empty( $user_data['username'] ) || empty( $user_data['discriminator'] ) || empty( $user_data['email'] ) ) {
+		if ( empty( $user_data['username'] ) || (empty( $user_data['discriminator'] ) && $user_data['discriminator'] !== "0") || empty( $user_data['email'] ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
Added a check that the discriminator isn't "0" based on new Discord API updates. Migrated usernames will have the discriminator `"0"` which is evaluated as empty by PHP. This is a temporary fix, once all users are migrated a discriminator will no longer be necessary. The check could potentially just be removed now. 